### PR TITLE
Added documentation for Layout/MultilineAssignmentLayout SupportedTypes

### DIFF
--- a/changelog/change_add_supported_types_documentation_multiline_assignment.md
+++ b/changelog/change_add_supported_types_documentation_multiline_assignment.md
@@ -1,0 +1,1 @@
+* [#1](https://github.com/rubocop-hq/rubocop/issues/1): Add documentation for Layout/MultilineAssignmentLayout SupportedTypes. ([@bhacaz][])

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -728,7 +728,7 @@ end
 
 | Categories
 | `{"module_inclusion"=>["include", "prepend", "extend"]}`
-| 
+|
 
 | ExpectedOrder
 | `module_inclusion`, `constants`, `public_class_methods`, `initializer`, `public_methods`, `protected_methods`, `private_methods`
@@ -4178,6 +4178,38 @@ foo = if expression
 end
 ----
 
+==== SupportedTypes: ['if']
+
+[source,ruby]
+----
+# good
+foo =
+  if expression
+    'bar'
+  end
+
+# good
+foo = [1].map do |i|
+  i + 1
+end
+----
+
+==== SupportedTypes: ['block']
+
+[source,ruby]
+----
+# good
+foo = if expression
+  'bar'
+end
+
+# good
+foo =
+  [1].map do |i|
+    'bar' * i
+  end
+----
+
 === Configurable attributes
 
 |===
@@ -4186,6 +4218,10 @@ end
 | EnforcedStyle
 | `new_line`
 | `same_line`, `new_line`
+
+| SupportedTypes
+| `block`, `case`, `class`, `if`, `kwbegin`, `module`
+| Array
 |===
 
 === References


### PR DESCRIPTION
I was looking for exactly the configurable attributes `SupportedTypes` for the cop Layout/MultilineAssignmentLayout.  But, I had to look in the code to found out that this attribute exist and in `config/default.yml` to found the available parameters. I thought it might be useful to add this info in the documentation. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop-hq/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
